### PR TITLE
Upgraded to jwt v5.3.0

### DIFF
--- a/client/rest.go
+++ b/client/rest.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/coinbase-samples/advanced-trade-sdk-go/credentials"
 	"github.com/coinbase-samples/core-go"
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,12 @@
 module github.com/coinbase-samples/advanced-trade-sdk-go
 
-go 1.19
+go 1.21
+
+toolchain go1.24.5
 
 require (
 	github.com/coinbase-samples/core-go v0.2.0
-	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/uuid v1.6.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/coinbase-samples/core-go v0.2.0 h1:2kEjNDmjC1BexDYVLHRBrY46ucLaDH8keveYvCgl6H8=
 github.com/coinbase-samples/core-go v0.2.0/go.mod h1:Toak9haPkoLB3w8gGBl8jd5FGDwXncypstvHzETqs6k=
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
-github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
+github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=


### PR DESCRIPTION
- Trader found a vulnerability in go SDK
- Reference [PR](https://github.com/coinbase-samples/advanced-trade-sdk-go/pull/16)