### PR TITLE
Add Ed25519 key support

### DIFF
--- a/client/rest.go
+++ b/client/rest.go
@@ -17,11 +17,16 @@
 package client
 
 import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/pem"
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/coinbase-samples/advanced-trade-sdk-go/credentials"
@@ -91,23 +96,26 @@ func AddAdvancedHttpHeaders(req *http.Request, path string, body []byte, cl core
 
 	c := cl.(*restClientImpl)
 
-	jwtToken := generateJwt(req.Method, path, req.Host, c.Credentials().AccessKey, c.Credentials().PrivatePemKey)
-
 	req.Header.Add("Accept", "application/json")
+	req.Header.Add("User-Agent", fmt.Sprintf("coinbase-advanced-go/%s", sdkVersion))
+
+	jwtToken, err := generateJwt(req.Method, path, req.Host, c.Credentials().AccessKey, c.Credentials().PrivatePemKey)
+	if err != nil {
+		// core-go's header hook can't return an error, so we can't abort the
+		// request from here. Log the cause and leave Authorization unset; the
+		// API rejects it with 401, which the caller gets as a normal error
+		// instead of the whole process being killed.
+		log.Printf("failed to generate JWT: %v", err)
+		return
+	}
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", jwtToken))
 
 }
 
-func generateJwt(method, path, host, keyName, privateKeyPEM string) string {
-	keyBytes := []byte(privateKeyPEM)
-	block, _ := pem.Decode(keyBytes)
-	if block == nil {
-		log.Fatal("failed to parse PEM block containing the key")
-	}
-
-	privateKey, err := x509.ParseECPrivateKey(block.Bytes)
+func generateJwt(method, path, host, keyName, privateKey string) (string, error) {
+	key, signingMethod, err := parsePrivateKey(privateKey)
 	if err != nil {
-		log.Fatalf("failed to parse EC private key: %v", err)
+		return "", fmt.Errorf("failed to parse private key: %w", err)
 	}
 
 	now := time.Now()
@@ -119,16 +127,76 @@ func generateJwt(method, path, host, keyName, privateKeyPEM string) string {
 		"uri": fmt.Sprintf("%s %s%s", method, host, path),
 	}
 
-	token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+	token := jwt.NewWithClaims(signingMethod, claims)
 	token.Header["kid"] = keyName
 	token.Header["nonce"] = uuid.New().String()
 
-	signedToken, err := token.SignedString(privateKey)
+	signedToken, err := token.SignedString(key)
 	if err != nil {
-		log.Fatalf("failed to sign token: %v", err)
+		return "", fmt.Errorf("failed to sign token: %w", err)
 	}
 
-	return signedToken
+	return signedToken, nil
+}
+
+var ecdsaDeprecationOnce sync.Once
+
+// Two key types are supported:
+//   - ECDSA (P-256), signed with ES256. Provided as a PEM-encoded key
+//     ("-----BEGIN EC PRIVATE KEY-----" or a PKCS#8 "-----BEGIN PRIVATE KEY-----").
+//   - Ed25519, signed with EdDSA. Provided either as a PKCS#8 PEM key or as a
+//     base64-encoded raw key (32-byte seed or 64-byte seed+public key), which is
+//     how the CDP portal hands out Ed25519 secrets.
+func parsePrivateKey(privateKey string) (any, jwt.SigningMethod, error) {
+	if strings.HasPrefix(strings.TrimSpace(privateKey), "-----BEGIN") {
+		block, _ := pem.Decode([]byte(privateKey))
+		if block == nil {
+			return nil, nil, fmt.Errorf("failed to decode PEM block containing the private key")
+		}
+
+		if block.Type == "EC PRIVATE KEY" {
+			key, err := x509.ParseECPrivateKey(block.Bytes)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to parse EC private key: %w", err)
+			}
+			warnEcdsaDeprecation()
+			return key, jwt.SigningMethodES256, nil
+		}
+
+		parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to parse PKCS#8 private key: %w", err)
+		}
+		switch k := parsed.(type) {
+		case *ecdsa.PrivateKey:
+			warnEcdsaDeprecation()
+			return k, jwt.SigningMethodES256, nil
+		case ed25519.PrivateKey:
+			return k, jwt.SigningMethodEdDSA, nil
+		default:
+			return nil, nil, fmt.Errorf("unsupported private key type %T; expected ECDSA (P-256) or Ed25519", parsed)
+		}
+	}
+
+	// Not PEM: treat the secret as a base64-encoded raw Ed25519 key. Strip any
+	raw, err := base64.StdEncoding.DecodeString(strings.Join(strings.Fields(privateKey), ""))
+	if err != nil {
+		return nil, nil, fmt.Errorf("private key is neither PEM nor valid base64: %w", err)
+	}
+	switch len(raw) {
+	case ed25519.SeedSize:
+		return ed25519.NewKeyFromSeed(raw), jwt.SigningMethodEdDSA, nil
+	case ed25519.PrivateKeySize:
+		return ed25519.PrivateKey(raw), jwt.SigningMethodEdDSA, nil
+	default:
+		return nil, nil, fmt.Errorf("ed25519 raw key must decode to %d or %d bytes, got %d", ed25519.SeedSize, ed25519.PrivateKeySize, len(raw))
+	}
+}
+
+func warnEcdsaDeprecation() {
+	ecdsaDeprecationOnce.Do(func() {
+		log.Println("warning: Ed25519 is the recommended CDP API key type. Consider switching to an Ed25519 key at https://portal.cdp.coinbase.com/")
+	})
 }
 
 func DefaultHttpClient() (http.Client, error) {

--- a/client/rest.go
+++ b/client/rest.go
@@ -26,7 +26,6 @@ import (
 	"log"
 	"net/http"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/coinbase-samples/advanced-trade-sdk-go/credentials"
@@ -139,8 +138,6 @@ func generateJwt(method, path, host, keyName, privateKey string) (string, error)
 	return signedToken, nil
 }
 
-var ecdsaDeprecationOnce sync.Once
-
 // Two key types are supported:
 //   - ECDSA (P-256), signed with ES256. Provided as a PEM-encoded key
 //     ("-----BEGIN EC PRIVATE KEY-----" or a PKCS#8 "-----BEGIN PRIVATE KEY-----").
@@ -159,7 +156,6 @@ func parsePrivateKey(privateKey string) (any, jwt.SigningMethod, error) {
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to parse EC private key: %w", err)
 			}
-			warnEcdsaDeprecation()
 			return key, jwt.SigningMethodES256, nil
 		}
 
@@ -169,7 +165,6 @@ func parsePrivateKey(privateKey string) (any, jwt.SigningMethod, error) {
 		}
 		switch k := parsed.(type) {
 		case *ecdsa.PrivateKey:
-			warnEcdsaDeprecation()
 			return k, jwt.SigningMethodES256, nil
 		case ed25519.PrivateKey:
 			return k, jwt.SigningMethodEdDSA, nil
@@ -191,12 +186,6 @@ func parsePrivateKey(privateKey string) (any, jwt.SigningMethod, error) {
 	default:
 		return nil, nil, fmt.Errorf("ed25519 raw key must decode to %d or %d bytes, got %d", ed25519.SeedSize, ed25519.PrivateKeySize, len(raw))
 	}
-}
-
-func warnEcdsaDeprecation() {
-	ecdsaDeprecationOnce.Do(func() {
-		log.Println("warning: Ed25519 is the recommended CDP API key type. Consider switching to an Ed25519 key at https://portal.cdp.coinbase.com/")
-	})
 }
 
 func DefaultHttpClient() (http.Client, error) {

--- a/client/version.go
+++ b/client/version.go
@@ -16,4 +16,4 @@
 
 package client
 
-const sdkVersion = "0.4.0"
+const sdkVersion = "0.4.1"


### PR DESCRIPTION
## What

Adds Ed25519 (EdDSA) signing support to the JWT auth path, alongside the existing ECDSA (ES256) keys.

- `parsePrivateKey` now detects the key type and picks the signing method:
  - ECDSA keys (PEM, SEC1 or PKCS#8) sign with ES256, same as before.
  - Ed25519 keys sign with EdDSA, accepted either as a PKCS#8 PEM or as the base64 raw key the CDP portal hands out (32-byte seed or 64-byte seed+pubkey). Whitespace in the base64 is tolerated.
- `generateJwt` now returns an error instead of calling `log.Fatal`, so a bad key no longer takes down the host process. Since core-go's header hook can't return an error, `AddAdvancedHttpHeaders` logs the cause and skips the Authorization header, and the API rejects with a recoverable 401.
- Adds a `User-Agent` header (`coinbase-advanced-go/<version>`) to match the other SDKs, and bumps the version to 0.4.1.

## Testing

Verified against the live API with both ECDSA and Ed25519 keys: JWT structural checks (alg, kid, sub, nbf/exp, distinct nonces, signature verifies) plus real REST calls all pass.